### PR TITLE
Added note about relevance ranking of results

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Options:
 ```
 
 By default, getpapers uses the EuropePMC API.
+Results are returned in order of relevance, most relevant first, least relevant last.
 
 ## Screenshot
 


### PR DESCRIPTION
Just noticed that the order of results returned was undocumented.
Thought I'd just add that results appear to be returned in a logical (relevance ranked) order.