### PR TITLE
test existance of JSON keys from EuPMC before access

### DIFF
--- a/lib/eupmc.js
+++ b/lib/eupmc.js
@@ -58,6 +58,11 @@ EuPmc.prototype.completeCallback = function(data) {
 
   var resp = data.responseWrapper;
 
+  if(!resp.hitCount[0] || !resp.resultList[0].result) { 
+    log.error("Malformed response from EuropePMC. Try running again.");
+    process.exit(1);
+  }
+  
   if (eupmc.first){
     eupmc.first = false;
     eupmc.hitcount = parseInt(resp.hitCount[0]);


### PR DESCRIPTION
This closes #73 which happens when we get back some JSON from eupmc that doesn't have the keys we expect.