### PR TITLE
Fix #89 - test for almost empty query from EuPMC

### DIFF
--- a/lib/eupmc.js
+++ b/lib/eupmc.js
@@ -61,8 +61,8 @@ EuPmc.prototype.completeCallback = function(data) {
 
   var resp = data.responseWrapper;
 
-  if(!resp.hitCount[0] || !resp.resultList[0].result) { 
-    log.error("Malformed response from EuropePMC. Try running again.");
+  if(!resp.hitCount || !resp.hitCount[0] || !resp.resultList[0].result) {
+    log.error("Malformed or empty response from EuropePMC. Try running again. Perhaps your query is wrong.");
     process.exit(1);
   }
   


### PR DESCRIPTION
This fixes #89 where we get back no response elements, nor a hitcount if you send a query like '-aardvark' or '*'