### PR TITLE
Improve CrossRef

### DIFF
--- a/bin/getpapers.js
+++ b/bin/getpapers.js
@@ -40,9 +40,13 @@ program
   .option('-k, --limit <int>',
     'limit the number of hits and downloads')
   .option('--filter-from-index-date <date>',
-    'filter only papers indexed after date')
+    'filter only papers indexed after date (inclusive)')
   .option('--filter-until-index-date <date>',
-    'filter only papers indexed before date')
+    'filter only papers indexed before date (inclusive)')
+    .option('--filter-from-pub-date <date>',
+      'filter only papers published after date (inclusive)')
+    .option('--filter-until-pub-date <date>',
+      'filter only papers published before date (inclusive)')
   .parse(process.argv)
 
 if (!process.argv.slice(2).length) {
@@ -105,6 +109,8 @@ options.hitlimit = parseInt(program.limit)
 options.noexecute = program.noexecute
 options.filterFromIndexDate = program.filterFromIndexDate
 options.filterUntilIndexDate = program.filterUntilIndexDate
+options.filterFromPubDate = program.filterFromPubDate
+options.filterUntilPubDate = program.filterUntilPubDate
 
 if (options.noexecute) {
   log.info('Running in no-execute mode, so nothing will be downloaded')

--- a/bin/getpapers.js
+++ b/bin/getpapers.js
@@ -39,20 +39,8 @@ program
     'save log to specified file in output directory as well as printing to terminal')
   .option('-k, --limit <int>',
     'limit the number of hits and downloads')
-  .option('--filter-from-index-date <date>',
-    'filter only papers indexed after date (inclusive)')
-  .option('--filter-until-index-date <date>',
-    'filter only papers indexed before date (inclusive)')
-  .option('--filter-from-pub-date <date>',
-    'filter only papers published after date (inclusive)')
-  .option('--filter-until-pub-date <date>',
-    'filter only papers published before date (inclusive)')
-  .option('--filter-until-created-date <date>',
-    'filter only papers created before date (inclusive)')
-  .option('--filter-from-created-date <date>',
-    'filter only papers created from date (inclusive)')
   .option('--filter <filter object>',
-    'filter by key value pair, passed straight to the crossref api')
+    'filter by key value pair, passed straight to the crossref api only')
   .parse(process.argv)
 
 if (!process.argv.slice(2).length) {
@@ -95,10 +83,17 @@ if (program.hasOwnProperty('logfile')) {
 
 // check arguments
 
-if (!program.query && !program.api==='crossref') {
+console.log(program.api)
+
+if (typeof program.query === "undefined" && program.api!=='crossref') {
   log.error('No query given. ' +
     'You must provide the --query argument.')
   process.exit(1)
+}
+
+if (program.filter && program.api!=='crossref') {
+  log.warn('Filter given but not using CrossRef api ' +
+    'so no filter applied.')
 }
 
 log.info('Searching using ' + program.api + ' API')
@@ -113,12 +108,6 @@ options.minedterms = program.minedterms
 options.all = program.all
 options.hitlimit = parseInt(program.limit)
 options.noexecute = program.noexecute
-options.filterFromIndexDate = program.filterFromIndexDate
-options.filterUntilIndexDate = program.filterUntilIndexDate
-options.filterFromPubDate = program.filterFromPubDate
-options.filterUntilPubDate = program.filterUntilPubDate
-options.filterUntilCreatedDate = program.filterUntilCreatedDate
-options.filterFromCreatedDate = program.filterFromCreatedDate
 options.filter = program.filter
 
 if (options.noexecute) {

--- a/bin/getpapers.js
+++ b/bin/getpapers.js
@@ -39,6 +39,10 @@ program
     'save log to specified file in output directory as well as printing to terminal')
   .option('-k, --limit <int>',
     'limit the number of hits and downloads')
+  .option('--filter-from-index-date <date>',
+    'filter only papers indexed after date')
+  .option('--filter-until-index-date <date>',
+    'filter only papers indexed before date')
   .parse(process.argv)
 
 if (!process.argv.slice(2).length) {
@@ -81,7 +85,7 @@ if (program.hasOwnProperty('logfile')) {
 
 // check arguments
 
-if (!program.query) {
+if (!program.query && !program.api==='crossref') {
   log.error('No query given. ' +
     'You must provide the --query argument.')
   process.exit(1)
@@ -99,6 +103,9 @@ options.minedterms = program.minedterms
 options.all = program.all
 options.hitlimit = parseInt(program.limit)
 options.noexecute = program.noexecute
+options.filterFromIndexDate = program.filterFromIndexDate
+options.filterUntilIndexDate = program.filterUntilIndexDate
+
 if (options.noexecute) {
   log.info('Running in no-execute mode, so nothing will be downloaded')
 } else {

--- a/bin/getpapers.js
+++ b/bin/getpapers.js
@@ -43,10 +43,14 @@ program
     'filter only papers indexed after date (inclusive)')
   .option('--filter-until-index-date <date>',
     'filter only papers indexed before date (inclusive)')
-    .option('--filter-from-pub-date <date>',
-      'filter only papers published after date (inclusive)')
-    .option('--filter-until-pub-date <date>',
-      'filter only papers published before date (inclusive)')
+  .option('--filter-from-pub-date <date>',
+    'filter only papers published after date (inclusive)')
+  .option('--filter-until-pub-date <date>',
+    'filter only papers published before date (inclusive)')
+  .option('--filter-until-created-date <date>',
+    'filter only papers created before date (inclusive)')
+  .option('--filter-from-created-date <date>',
+    'filter only papers created from date (inclusive)')
   .parse(process.argv)
 
 if (!process.argv.slice(2).length) {
@@ -111,6 +115,8 @@ options.filterFromIndexDate = program.filterFromIndexDate
 options.filterUntilIndexDate = program.filterUntilIndexDate
 options.filterFromPubDate = program.filterFromPubDate
 options.filterUntilPubDate = program.filterUntilPubDate
+options.filterUntilCreatedDate = program.filterUntilCreatedDate
+options.filterFromCreatedDate = program.filterFromCreatedDate
 
 if (options.noexecute) {
   log.info('Running in no-execute mode, so nothing will be downloaded')

--- a/bin/getpapers.js
+++ b/bin/getpapers.js
@@ -51,6 +51,8 @@ program
     'filter only papers created before date (inclusive)')
   .option('--filter-from-created-date <date>',
     'filter only papers created from date (inclusive)')
+  .option('--filter <filter object>',
+    'filter by key value pair, passed straight to the crossref api')
   .parse(process.argv)
 
 if (!process.argv.slice(2).length) {
@@ -117,6 +119,7 @@ options.filterFromPubDate = program.filterFromPubDate
 options.filterUntilPubDate = program.filterUntilPubDate
 options.filterUntilCreatedDate = program.filterUntilCreatedDate
 options.filterFromCreatedDate = program.filterFromCreatedDate
+options.filter = program.filter
 
 if (options.noexecute) {
   log.info('Running in no-execute mode, so nothing will be downloaded')

--- a/lib/crossref.js
+++ b/lib/crossref.js
@@ -6,6 +6,7 @@ var mkdirp = require('mkdirp')
 var _ = require('lodash')
 var urlDl = require('./download.js')
 var CrossRefAPI = require('crossref')
+var sanitize = require("sanitize-filename")
 
 var CrossRef = function (opts) {
   this.baseurl = 'http://api.crossref.org/works'
@@ -238,7 +239,7 @@ CrossRef.prototype.urlQueueBuilder = function (urls, type, rename) {
 
 CrossRef.prototype.writeRecord = function (record, crossref) {
   var json = JSON.stringify(record, null, 2)
-  var id = crossref.getIdentifier(record).id
+  var id = sanitize(crossref.getIdentifier(record).id)
   mkdirp.sync(id)
   fs.writeFileSync(id + '/crossref_result.json', json)
 }

--- a/lib/crossref.js
+++ b/lib/crossref.js
@@ -52,7 +52,9 @@ CrossRef.prototype.search = function (query) {
   var filterList = {'filterFromIndexDate':'from-index-date',
                     'filterUntilIndexDate':'until-index-date',
                     'filterFromPubDate':'from-pub-date',
-                    'filterUntilPubDate':'until-pub-date'
+                    'filterUntilPubDate':'until-pub-date',
+                    'filterUntilCreatedDate':'until-created-date',
+                    'filterFromCreatedDate':'from-created-date'
                   }
 
   var addFilter = function(message, filterkey, optionName) {

--- a/lib/crossref.js
+++ b/lib/crossref.js
@@ -101,6 +101,10 @@ CrossRef.prototype.handleSearchResults = function (crossref) {
       crossref.allresults.length +
       ' unique results identified')
   }
+  if (crossref.allresults.length > crossref.hitlimit) {
+    crossref.allresults = crossref.allresults.slice(0,crossref.hitlimit)
+    log.info('limiting hits')
+  }
 
   // write the full result set to a file
   log.info('Saving result metadata')

--- a/lib/crossref.js
+++ b/lib/crossref.js
@@ -48,7 +48,7 @@ CrossRef.prototype.search = function (query) {
   if (query != null) { message.query = query}
   message.rows = crossref.pagesize
 
-// mapping of commandline option to the crossref facet name
+// mapping of commandlinse option to the crossref facet name
   var filterList = {'filterFromIndexDate':'from-index-date',
                     'filterUntilIndexDate':'until-index-date',
                     'filterFromPubDate':'from-pub-date',
@@ -67,25 +67,6 @@ for (var key in filterList){
 }
 }
 
-
-/*
-  if (crossref.opts.filterFromIndexDate) {
-    message.filter = message.filter ? message.filter : {}
-    message.filter['from-index-date'] = crossref.opts.filterFromIndexDate
-  }
-  if (crossref.opts.filterUntilIndexDate) {
-    message.filter = message.filter ? message.filter : {}
-    message.filter['until-index-date'] = crossref.opts.filterUntilIndexDate
-  }
-  if (crossref.opts.filterFromPubDate) {
-    message.filter = message.filter ? message.filter : {}
-    message.filter['from-pub-date'] = crossref.opts.filterFromPubDate
-  }
-  if (crossref.opts.filterUntilPubDate) {
-    message.filter = message.filter ? message.filter : {}
-    message.filter['until-pub-date'] = crossref.opts.filterUntilPubDate
-  }
-*/
   CrossRefAPI.works(message, pageQuery)
 }
 

--- a/lib/crossref.js
+++ b/lib/crossref.js
@@ -48,6 +48,27 @@ CrossRef.prototype.search = function (query) {
   if (query != null) { message.query = query}
   message.rows = crossref.pagesize
 
+// mapping of commandline option to the crossref facet name
+  var filterList = {'filterFromIndexDate':'from-index-date',
+                    'filterUntilIndexDate':'until-index-date',
+                    'filterFromPubDate':'from-pub-date',
+                    'filterUntilPubDate':'until-pub-date'
+                  }
+
+  var addFilter = function(message, filterkey, optionName) {
+    message.filter = message.filter ? message.filter : {}
+      message.filter[optionName]=crossref.opts[filterkey]
+    return message
+  }
+
+for (var key in filterList){
+  if (crossref.opts[key]) {
+  message = addFilter(message, key, filterList[key])
+}
+}
+
+
+/*
   if (crossref.opts.filterFromIndexDate) {
     message.filter = message.filter ? message.filter : {}
     message.filter['from-index-date'] = crossref.opts.filterFromIndexDate
@@ -64,6 +85,7 @@ CrossRef.prototype.search = function (query) {
     message.filter = message.filter ? message.filter : {}
     message.filter['until-pub-date'] = crossref.opts.filterUntilPubDate
   }
+*/
   CrossRefAPI.works(message, pageQuery)
 }
 

--- a/lib/crossref.js
+++ b/lib/crossref.js
@@ -45,11 +45,16 @@ CrossRef.prototype.search = function (query) {
   }
 
   var message = {}
-  if (query =! null) { message.query = query}
+  if (query != null) { message.query = query}
   message.rows = crossref.pagesize
+
   if (crossref.opts.filterFromIndexDate) {
-    message.filter = {}
+    message.filter = message.filter ? message.filter : {}
     message.filter['from-index-date'] = crossref.opts.filterFromIndexDate
+  }
+  if (crossref.opts.filterUntilIndexDate) {
+    message.filter = message.filter ? message.filter : {}
+    message.filter['until-index-date'] = crossref.opts.filterUntilIndexDate
   }
   CrossRefAPI.works(message, pageQuery)
 }

--- a/lib/crossref.js
+++ b/lib/crossref.js
@@ -16,7 +16,7 @@ var CrossRef = function (opts) {
 
 CrossRef.prototype.search = function (query) {
   var crossref = this
-
+  crossref.pagesize = 1000
   crossref.hitlimit = crossref.opts.hitlimit ? crossref.opts.hitlimit : 0
   crossref.hitcount = 0
   crossref.first = true
@@ -29,6 +29,7 @@ CrossRef.prototype.search = function (query) {
       crossref.first = false
       crossref.hitcount = message['total-results']
       log.info('Found', crossref.hitcount, 'results')
+      if (crossref.opts.noexecute){ process.exit(0) }
     }
 
     crossref.allresults = crossref.allresults.concat(objects)
@@ -43,10 +44,14 @@ CrossRef.prototype.search = function (query) {
     }
   }
 
-  CrossRefAPI.works({
-    query: query,
-    rows: 1000
-  }, pageQuery)
+  var message = {}
+  if (query =! null) { message.query = query}
+  message.rows = crossref.pagesize
+  if (crossref.opts.filterFromIndexDate) {
+    message.filter = {}
+    message.filter['from-index-date'] = crossref.opts.filterFromIndexDate
+  }
+  CrossRefAPI.works(message, pageQuery)
 }
 
 CrossRef.prototype.timeoutCallback = function (ms) {

--- a/lib/crossref.js
+++ b/lib/crossref.js
@@ -48,33 +48,10 @@ CrossRef.prototype.search = function (query) {
   if (query != null) { message.query = query}
   message.rows = crossref.pagesize
 
-// mapping of commandlinse option to the crossref facet name
-  var filterList = {'filterFromIndexDate':'from-index-date',
-                    'filterUntilIndexDate':'until-index-date',
-                    'filterFromPubDate':'from-pub-date',
-                    'filterUntilPubDate':'until-pub-date',
-                    'filterUntilCreatedDate':'until-created-date',
-                    'filterFromCreatedDate':'from-created-date'
-                  }
-
-  var addFilter = function(message, filterkey, optionName) {
-    message.filter = message.filter ? message.filter : {}
-      message.filter[optionName]=crossref.opts[filterkey]
-    return message
-  }
-
-for (var key in filterList){
-  if (crossref.opts[key]) {
-  message = addFilter(message, key, filterList[key])
-}
-}
-
 if (crossref.opts.filter) {
   var filters = crossref.opts.filter.split(',')
-  console.log(filters)
   message.filter = message.filter ? message.filter : {}
   for (var singleFilter of filters){
-    console.log(singleFilter)
     message.filter[singleFilter.split(':')[0]] = singleFilter.split(':')[1]
   }
 }

--- a/lib/crossref.js
+++ b/lib/crossref.js
@@ -17,7 +17,6 @@ var CrossRef = function (opts) {
 CrossRef.prototype.search = function (query) {
   var crossref = this
   crossref.pagesize = 1000
-  crossref.hitlimit = crossref.opts.hitlimit ? crossref.opts.hitlimit : 0
   crossref.hitcount = 0
   crossref.first = true
   crossref.allresults = []
@@ -28,6 +27,7 @@ CrossRef.prototype.search = function (query) {
     if (crossref.first) {
       crossref.first = false
       crossref.hitcount = message['total-results']
+      crossref.hitlimit = crossref.opts.hitlimit ? crossref.opts.hitlimit : crossref.hitcount
       log.info('Found', crossref.hitcount, 'results')
       if (crossref.opts.noexecute){ process.exit(0) }
     }
@@ -66,7 +66,6 @@ for (var key in filterList){
   message = addFilter(message, key, filterList[key])
 }
 }
-
   CrossRefAPI.works(message, pageQuery)
 }
 

--- a/lib/crossref.js
+++ b/lib/crossref.js
@@ -68,6 +68,17 @@ for (var key in filterList){
   message = addFilter(message, key, filterList[key])
 }
 }
+
+if (crossref.opts.filter) {
+  var filters = crossref.opts.filter.split(',')
+  console.log(filters)
+  message.filter = message.filter ? message.filter : {}
+  for (var singleFilter of filters){
+    console.log(singleFilter)
+    message.filter[singleFilter.split(':')[0]] = singleFilter.split(':')[1]
+  }
+}
+
   CrossRefAPI.works(message, pageQuery)
 }
 

--- a/lib/crossref.js
+++ b/lib/crossref.js
@@ -56,6 +56,14 @@ CrossRef.prototype.search = function (query) {
     message.filter = message.filter ? message.filter : {}
     message.filter['until-index-date'] = crossref.opts.filterUntilIndexDate
   }
+  if (crossref.opts.filterFromPubDate) {
+    message.filter = message.filter ? message.filter : {}
+    message.filter['from-pub-date'] = crossref.opts.filterFromPubDate
+  }
+  if (crossref.opts.filterUntilPubDate) {
+    message.filter = message.filter ? message.filter : {}
+    message.filter['until-pub-date'] = crossref.opts.filterUntilPubDate
+  }
   CrossRefAPI.works(message, pageQuery)
 }
 

--- a/lib/download.js
+++ b/lib/download.js
@@ -5,6 +5,7 @@ var util = require('util')
 , mkdirp = require('mkdirp')
 , _ = require('lodash')
 , ProgressBar = require('progress');
+var sanitize = require("sanitize-filename")
 
 exports.downloadurlQueue = function(fullurlQueue, nextDlTaskcb) {
   var failed = [];
@@ -40,8 +41,8 @@ function downloadURL(urlObj) {
   var url = urlObj.url;
   var id = urlObj.id;
   var type = urlObj.type;
-  var rename = urlObj.rename;
-  var base = id + '/';
+  var rename = sanitize(urlObj.rename);
+  var base = sanitize(id) + '/';
   log.debug('Creating directory: ' + base);
   mkdirp.sync(base);
   log.debug('Downloading ' + type + ': ' + url);

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "mkdirp": "^0.5.0",
     "progress": "^1.1.8",
     "restler": "^3.2.2",
-    "winston": "~1.0.0"
+    "winston": "~1.0.0",
+    "sanitize-filename": "^1.6.0" 
   },
   "bin": {
     "getpapers": "bin/getpapers.js"


### PR DESCRIPTION
This patch:
* allows query-less searches when using crossref
* allows filtering by both index and publication date using crossref
* Correctly handles limiting the number of results with CrossRef
* Sanitizes filenames before writing either the full text or metadata to not make subdirs when the doi has a '/' in it.
