### PR TITLE
Use requests rather than restler

### DIFF
--- a/lib/arxiv.js
+++ b/lib/arxiv.js
@@ -1,12 +1,14 @@
-var rest = require('restler')
-, util = require('util')
+var util = require('util')
 , fs = require('fs')
 , chalk = require('chalk')
 , got = require('got')
 , mkdirp = require('mkdirp')
 , _ = require('lodash')
 , ProgressBar = require('progress')
+, request = require('requestretry')
 , urlDl = require('./download.js');
+
+var parseString = require('xml2js').parseString
 
 var ArXiv = function(opts) {
 
@@ -56,8 +58,14 @@ ArXiv.prototype.pageQuery = function() {
   thisQueryUrl += pageterm;
 
   log.debug(thisQueryUrl);
-  var rq = rest.get(thisQueryUrl, {timeout: 40000, parser: rest.parsers.xml});
-  rq.on('complete', arxiv.completeCallback.bind(arxiv));
+  var rq = request.get(thisQueryUrl);
+  var convertXML2JSON = function (data) {
+    //console.log(data.body)
+    parseString(data.body, function (err, datum) {
+      cb = arxiv.completeCallback.bind(arxiv, datum)
+      cb() } )
+  }
+  rq.on('complete', convertXML2JSON);
   rq.on('timeout', arxiv.timeoutCallback);
 
 }

--- a/lib/eupmc.js
+++ b/lib/eupmc.js
@@ -1,5 +1,4 @@
-var rest = require('restler')
-, util = require('util')
+var util = require('util')
 , fs = require('fs')
 , chalk = require('chalk')
 , got = require('got')
@@ -7,7 +6,10 @@ var rest = require('restler')
 , _ = require('lodash')
 , ProgressBar = require('progress')
 , urlDl = require('./download.js')
+, request = require('requestretry')
 , glob = require('matched');
+
+var parseString = require('xml2js').parseString
 
 var EuPmc = function(opts) {
 
@@ -51,8 +53,14 @@ EuPmc.prototype.pageQuery = function() {
   }
 
   log.debug(thisQueryUrl);
-  var rq = rest.get(thisQueryUrl, {timeout: 20000});
-  rq.on('complete', eupmc.completeCallback.bind(eupmc));
+  var rq = request.get({url: thisQueryUrl, headers: { 'Accept': 'application/json'}});
+  var convertXML2JSON = function (data) {
+    //console.log(data.body)
+    parseString(data.body, function (err, datum) {
+      cb = eupmc.completeCallback.bind(eupmc, datum)
+      cb() } )
+  }
+  rq.on('complete', convertXML2JSON);
   rq.on('timeout', eupmc.timeoutCallback);
 
 }

--- a/lib/eupmc.js
+++ b/lib/eupmc.js
@@ -27,7 +27,7 @@ EuPmc.prototype.search = function(query) {
   if (!eupmc.opts.all) {
     query += " OPEN_ACCESS:y";
   }
-  eupmc.pagesize = '100'
+  eupmc.pagesize = '1000'
   var options = { resulttype: 'core', pageSize: eupmc.pagesize };
   eupmc.queryurl = eupmc.buildQuery(query, options);
   eupmc.first = true;

--- a/lib/ieee.js
+++ b/lib/ieee.js
@@ -1,11 +1,13 @@
-var rest = require('restler')
-, util = require('util')
+var util = require('util')
 , fs = require('fs')
 , chalk = require('chalk')
 , got = require('got')
 , mkdirp = require('mkdirp')
 , _ = require('lodash')
+, request = require('requestretry')
 , ProgressBar = require('progress');
+
+var parseString = require('xml2js').parseString
 
 var IEEE = function(opts) {
 
@@ -72,8 +74,14 @@ IEEE.prototype.pageQuery = function() {
   }
 
   log.debug(thisQueryUrl);
-  var rq = rest.get(thisQueryUrl, {timeout: 20000, parser: rest.parsers.xml});
-  rq.on('complete', ieee.completeCallback.bind(ieee));
+  var rq = request.get({url: thisQueryUrl, headers: { 'Accept': 'application/json'}});
+  var convertXML2JSON = function (data) {
+    //console.log(data.body)
+    parseString(data.body, function (err, datum) {
+      cb = ieee.completeCallback.bind(ieee, datum)
+      cb() } )
+  }
+  rq.on('complete', convertXML2JSON);
   rq.on('timeout', ieee.timeoutCallback.bind(ieee));
 
 }

--- a/package.json
+++ b/package.json
@@ -39,8 +39,11 @@
     "matched": "^0.4.1",
     "mkdirp": "^0.5.0",
     "progress": "^1.1.8",
+    "request-retry": "^0.1.1",
+    "requestretry": "^1.9.0",
     "restler": "^3.2.2",
-    "winston": "~1.0.0"
+    "winston": "~1.0.0",
+    "xml2js": "^0.4.17"
   },
   "bin": {
     "getpapers": "bin/getpapers.js"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "progress": "^1.1.8",
     "request-retry": "^0.1.1",
     "requestretry": "^1.9.0",
-    "restler": "^3.2.2",
     "winston": "~1.0.0",
     "xml2js": "^0.4.17"
   },


### PR DESCRIPTION
Ported the metadata downloads to requests and use requestsretry.

Restler is not really actively developed any more; porting to requests was fairly simple. We can also use requestsretry which may help some timeouts that people suffer at the moment.

Finally we bump the number of results per page for EuPMC because they have a problem with paging when there are more than 16 pages (oddly specific I know)
