### PR TITLE
Write metadata on failure and allow restarting of failed downloads

### DIFF
--- a/bin/getpapers.js
+++ b/bin/getpapers.js
@@ -39,6 +39,8 @@ program
     'save log to specified file in output directory as well as printing to terminal')
   .option('-k, --limit <int>',
     'limit the number of hits and downloads')
+  .option('-r, --restart',
+    'restart file downloads after failure')
   .parse(process.argv)
 
 if (!process.argv.slice(2).length) {
@@ -96,6 +98,7 @@ options.xml = program.xml
 options.pdf = program.pdf
 options.supp = program.supp
 options.minedterms = program.minedterms
+options.restart = program.restart
 options.all = program.all
 options.hitlimit = parseInt(program.limit)
 options.noexecute = program.noexecute

--- a/lib/arxiv.js
+++ b/lib/arxiv.js
@@ -1,12 +1,14 @@
-var rest = require('restler')
-, util = require('util')
+var util = require('util')
 , fs = require('fs')
 , chalk = require('chalk')
 , got = require('got')
 , mkdirp = require('mkdirp')
 , _ = require('lodash')
 , ProgressBar = require('progress')
+, request = require('requestretry')
 , urlDl = require('./download.js');
+
+var parseString = require('xml2js').parseString
 
 var ArXiv = function(opts) {
 
@@ -56,8 +58,14 @@ ArXiv.prototype.pageQuery = function() {
   thisQueryUrl += pageterm;
 
   log.debug(thisQueryUrl);
-  var rq = rest.get(thisQueryUrl, {timeout: 40000, parser: rest.parsers.xml});
-  rq.on('complete', arxiv.completeCallback.bind(arxiv));
+  var rq = request.get(thisQueryUrl);
+  var convertXML2JSON = function (data) {
+    //console.log(data.body)
+    parseString(data.body, function (err, datum) {
+      cb = arxiv.completeCallback.bind(arxiv, datum)
+      cb() } )
+  }
+  rq.on('complete', convertXML2JSON);
   rq.on('timeout', arxiv.timeoutCallback);
 
 }

--- a/lib/download.js
+++ b/lib/download.js
@@ -1,7 +1,7 @@
 var util = require('util')
 , fs = require('fs')
 , chalk = require('chalk')
-, got = require('got')
+, requestretry = require('requestretry')
 , mkdirp = require('mkdirp')
 , _ = require('lodash')
 , ProgressBar = require('progress');
@@ -11,9 +11,7 @@ exports.downloadurlQueue = function(fullurlQueue, nextDlTaskcb) {
   var retries = 0;
   var missing = 0;
 
-  urlQueue = fullurlQueue; //urlQueue needs to be global unless
-                          //we put these other functions inside
-                          //this one.
+  var urlQueue = fullurlQueue;
 
   //Setup ProgressBar
   var progmsg = 'Downloading files [:bar] :percent' +
@@ -32,8 +30,32 @@ exports.downloadurlQueue = function(fullurlQueue, nextDlTaskcb) {
 function nextUrlTask() {
   if (urlQueue instanceof Array && urlQueue.length > 0) {
     var urlObj = urlQueue.splice(0,1)[0];
-    downloadURL(urlObj);
+    testIfFileExists(urlObj, downloadURL);
   }
+}
+
+// Run callback if file doesn't exist
+function testIfFileExists(urlObj, cb) {
+  dlprogress.tick();
+  var url = urlObj.url;
+  var id = urlObj.id;
+  var type = urlObj.type;
+  var rename = urlObj.rename;
+  var base = id + '/';
+  fs.readFile(base + rename, (err, data) => {
+    if ((err)&&(err.code=='ENOENT')) {
+      cb(urlObj)
+      //File doesn't exist so start download procedure
+    }
+    else if (err) {
+      throw err
+    }
+    else {
+      log.info('File of type: '+type+' and id: '+id+' already exists. Skipping.')
+      nextUrlTask(urlQueue)
+      return
+    }
+  })
 }
 
 function downloadURL(urlObj) {
@@ -45,17 +67,6 @@ function downloadURL(urlObj) {
   log.debug('Creating directory: ' + base);
   mkdirp.sync(base);
 
-  fs.readFile(base + rename, (err, data) => {
-    if ((err)&&(err.code=='ENOENT')) {
-      log.info('File of type: '+type+' and id: '+id+' already exists. Skipping.')
-      nextUrlTask(urlQueue)
-      return
-    }
-    else if (err) {
-      throw err
-    }
-  })
-
   log.debug('Downloading ' + type + ': ' + url);
   var options = {
     timeout: 15000,
@@ -63,25 +74,18 @@ function downloadURL(urlObj) {
     retries: 3
   }
 
-  var get = got(url, options, function(err, data, res) {
-    dlprogress.tick();
-    if (err) {
-      if (err.code === 'ETIMEDOUT' || err.code === 'ESOCKETTIMEDOUT') {
-        log.warn('Download timed out for URL ' + url);
-      }
-      if (!res) {
-        failed.push(url);
-      } else if ((res.statusCode == 404) && !(fourohfour === null)) {
-        fourohfour();
-      } else {
-        failed.push(url);
-      }
-      done();
-    } else {
+  function handleDownload(data) {
       fs.writeFile(base + rename, data, done);
-    }
       nextUrlTask(urlQueue);
-    });
+    }
+
+  function throwErr(err){
+    if (err) throw err
+  }
+
+  rq = requestretry.get({url: url, fullResponse: false} );
+  rq.then(handleDownload)
+  rq.catch(throwErr)
 }
 
   var donefunc = function() {
@@ -98,7 +102,7 @@ function downloadURL(urlObj) {
     nextDlTaskcb();
   }
 
-  var done = _.after(urlQueue.length, donefunc);
+  var done = _.after(fullurlQueue.length, donefunc);
 
   var fourohfour = function() {
     missing ++;

--- a/lib/download.js
+++ b/lib/download.js
@@ -44,6 +44,18 @@ function downloadURL(urlObj) {
   var base = id + '/';
   log.debug('Creating directory: ' + base);
   mkdirp.sync(base);
+
+  fs.readFile(base + rename, (err, data) => {
+    if ((err)&&(err.code=='ENOENT')) {
+      log.info('File of type: '+type+' and id: '+id+' already exists. Skipping.')
+      nextUrlTask(urlQueue)
+      return
+    }
+    else if (err) {
+      throw err
+    }
+  })
+
   log.debug('Downloading ' + type + ': ' + url);
   var options = {
     timeout: 15000,
@@ -70,7 +82,7 @@ function downloadURL(urlObj) {
     }
       nextUrlTask(urlQueue);
     });
-  }
+}
 
   var donefunc = function() {
     if (failed.length > 0) {

--- a/lib/eupmc.js
+++ b/lib/eupmc.js
@@ -1,6 +1,4 @@
-
-var rest = require('restler')
-, util = require('util')
+var util = require('util')
 , fs = require('fs')
 , chalk = require('chalk')
 , got = require('got')
@@ -8,7 +6,10 @@ var rest = require('restler')
 , _ = require('lodash')
 , ProgressBar = require('progress')
 , urlDl = require('./download.js')
+, requestretry = require('requestretry')
 , glob = require('matched');
+
+var parseString = require('xml2js').parseString
 
 var EuPmc = function(opts) {
 
@@ -26,7 +27,7 @@ EuPmc.prototype.search = function(query) {
   if (!eupmc.opts.all) {
     query += " OPEN_ACCESS:y";
   }
-  eupmc.pagesize = '100'
+  eupmc.pagesize = '1000'
   var options = { resulttype: 'core', pageSize: eupmc.pagesize };
   eupmc.queryurl = eupmc.buildQuery(query, options);
   eupmc.first = true;
@@ -72,8 +73,17 @@ EuPmc.prototype.pageQuery = function() {
   }
 
   log.debug(thisQueryUrl);
-  var rq = rest.get(thisQueryUrl, {timeout: 20000});
-  rq.on('complete', eupmc.completeCallback.bind(eupmc));
+  var rq = requestretry.get({url: thisQueryUrl,
+                            maxAttempts: 50,
+                            retryStrategy: requestretry.RetryStrategies.HTTPOrNetworkError,
+                           });
+  var convertXML2JSON = function (data) {
+    parseString(data.body, function (err, datum) {
+      if (err) throw err
+      cb = eupmc.completeCallback.bind(eupmc, datum)
+      cb() } )
+  }
+  rq.then(convertXML2JSON);
   rq.on('timeout', eupmc.timeoutCallback);
 
 }

--- a/lib/eupmc.js
+++ b/lib/eupmc.js
@@ -119,6 +119,12 @@ EuPmc.prototype.timeoutCallback = function(ms) {
 
   log.error('Did not get a response from Europe PMC within ' + ms + 'ms');
 
+  if (eupmc.allresults) {
+    log.info('Handling the limited number of search results we got.')
+    log.warn('The metadata download did not finish so you *will* be missing some results')
+    eupmc.handleSearchResults(eupmc)
+  }
+
 }
 
 EuPmc.prototype.buildQuery = function(query, options) {

--- a/lib/eupmc.js
+++ b/lib/eupmc.js
@@ -1,3 +1,4 @@
+
 var rest = require('restler')
 , util = require('util')
 , fs = require('fs')
@@ -35,8 +36,28 @@ EuPmc.prototype.search = function(query) {
   eupmc.allresults = [];
   eupmc.iter = 1; //we always get back the first page
 
-  eupmc.pageQuery();
+  if (eupmc.opts.restart) {
+        fs.readFile('eupmc_results.json', (err,data) => {
+          if ((err) && (err.code == 'ENOENT')) {
+            log.error('No existing download to restart')
+            process.exit(1)
+          }
+          else if (err) {
+            throw err
+          }
+          else {
+            log.info('Restarting previous download')
+            eupmc.allresults=JSON.parse(data)
+            eupmc.addDlTasks()
+          }
+        } )
 
+
+
+  }
+  else {
+    eupmc.pageQuery();
+  }
 }
 
 EuPmc.prototype.pageQuery = function() {
@@ -191,6 +212,12 @@ EuPmc.prototype.handleSearchResults = function(eupmc) {
     log.info('Fulltext HTML URL list written to ' + filename);
   }
 
+  eupmc.addDlTasks()
+
+}
+
+EuPmc.prototype.addDlTasks = function() {
+  eupmc = this
   var dlTasks = [];
 
   // download the fullText XML
@@ -215,7 +242,6 @@ EuPmc.prototype.handleSearchResults = function(eupmc) {
   }
 
   eupmc.runDlTasks(dlTasks);
-
 }
 
 EuPmc.prototype.runDlTasks = function(dlTasks) {

--- a/lib/eupmc.js
+++ b/lib/eupmc.js
@@ -137,6 +137,7 @@ EuPmc.prototype.completeCallback = function(data) {
 }
 
 EuPmc.prototype.timeoutCallback = function(ms) {
+  eupmc = this
 
   log.error('Did not get a response from Europe PMC within ' + ms + 'ms');
 

--- a/lib/ieee.js
+++ b/lib/ieee.js
@@ -1,11 +1,13 @@
-var rest = require('restler')
-, util = require('util')
+var util = require('util')
 , fs = require('fs')
 , chalk = require('chalk')
 , got = require('got')
 , mkdirp = require('mkdirp')
 , _ = require('lodash')
+, request = require('requestretry')
 , ProgressBar = require('progress');
+
+var parseString = require('xml2js').parseString
 
 var IEEE = function(opts) {
 
@@ -72,8 +74,14 @@ IEEE.prototype.pageQuery = function() {
   }
 
   log.debug(thisQueryUrl);
-  var rq = rest.get(thisQueryUrl, {timeout: 20000, parser: rest.parsers.xml});
-  rq.on('complete', ieee.completeCallback.bind(ieee));
+  var rq = request.get({url: thisQueryUrl, headers: { 'Accept': 'application/json'}});
+  var convertXML2JSON = function (data) {
+    //console.log(data.body)
+    parseString(data.body, function (err, datum) {
+      cb = ieee.completeCallback.bind(ieee, datum)
+      cb() } )
+  }
+  rq.on('complete', convertXML2JSON);
   rq.on('timeout', ieee.timeoutCallback.bind(ieee));
 
 }

--- a/package.json
+++ b/package.json
@@ -39,8 +39,10 @@
     "matched": "^0.4.1",
     "mkdirp": "^0.5.0",
     "progress": "^1.1.8",
-    "restler": "^3.2.2",
-    "winston": "~1.0.0"
+    "request-retry": "^0.1.1",
+    "requestretry": "^1.12.0",
+    "winston": "~1.0.0",
+    "xml2js": "^0.4.17"
   },
   "bin": {
     "getpapers": "bin/getpapers.js"


### PR DESCRIPTION
This patch still tries to handle search results if the metadata download fails. It also enables restarting a download of files with the -r option. Which is necessary if one suffers a timeout. Finally it prevents downloading a file which already exists and moves on to the next download.