### PR TITLE
use nextCursorMark rather than increment page for paging

### DIFF
--- a/lib/eupmc.js
+++ b/lib/eupmc.js
@@ -38,7 +38,7 @@ EuPmc.prototype.search = function(query) {
   eupmc.hitcount = 0;
   eupmc.residualhits = 0;
   eupmc.allresults = [];
-  eupmc.iter = 1; //we always get back the first page
+  eupmc.nextCursorMark = '*'; //we always get back the first page
 
   if (eupmc.opts.restart) {
         fs.readFile('eupmc_results.json', (err,data) => {
@@ -70,10 +70,8 @@ EuPmc.prototype.pageQuery = function() {
 
   var thisQueryUrl = eupmc.queryurl + '';
 
-  if (eupmc.iter > 0) {
-    var pageterm = '&page=' + eupmc.iter;
+    var pageterm = '&cursorMark=' + eupmc.nextCursorMark;
     thisQueryUrl += pageterm;
-  }
 
   log.debug(thisQueryUrl);
 
@@ -147,7 +145,7 @@ EuPmc.prototype.completeCallback = function(data) {
     if (eupmc.hitlimit - eupmc.allresults.length < eupmc.pagesize) {
      eupmc.residualhits = eupmc.hitlimit - eupmc.allresults.length;
     }
-    eupmc.iter += 1;
+    eupmc.nextCursorMark = resp.nextCursorMark[0];
     eupmc.pageQuery();
   } else {
     log.info('Done collecting results');


### PR DESCRIPTION
This seems to work correctly with the new EuPMC api.

*Doesn't* handle situations where we don't get a nextCursorMark which may happen. Also I think there is a chance that if we get back less results than initially announced we might keep following this maze forever, Although this could possibly have happened in the past as well.