### PR TITLE
use version_compare not semver

### DIFF
--- a/lib/eupmc.js
+++ b/lib/eupmc.js
@@ -8,7 +8,7 @@ var util = require('util')
 , urlDl = require('./download.js')
 , requestretry = require('requestretry')
 , glob = require('matched')
-var semver = require('semver')
+, vc = require('version_compare')
 
 
 var parseString = require('xml2js').parseString
@@ -69,7 +69,7 @@ EuPmc.prototype.search = function(query) {
 }
 
 EuPmc.prototype.testApi = function(version) {
-  if(!semver.satisfies(version, EuPMCVersion)) {
+  if(!vc.matches(version, EuPMCVersion)) {
     log.warn('This version of getpapers wasn\'t built with this version of the EuPMC api in mind')
     log.warn(`getpapers EuPMCVersion: ${EuPMCVersion} vs. ${version} reported by api` )
   }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "requestretry": "^1.12.0",
     "restler": "^3.2.2",
     "sanitize-filename": "^1.6.0",
-    "semver": "^5.3.0",
+    "version_compare": "0.0.3",
     "winston": "~1.0.0",
     "xml2js": "^0.4.17"
   },


### PR DESCRIPTION
Test version number with version_compare not semver because apparently EuPMC aren't using semver like we thought. Fixes #149 