### PR TITLE
Use https to Fix 168

### DIFF
--- a/lib/eupmc.js
+++ b/lib/eupmc.js
@@ -13,11 +13,11 @@ var log = require('winston')
 
 var parseString = require('xml2js').parseString
 
-var EuPMCVersion = '5.1.1'
+var EuPMCVersion = '5.2.2'
 
 var EuPmc = function (opts) {
   var eupmc = this
-  this.baseurl = 'http://www.ebi.ac.uk/' +
+  this.baseurl = 'https://www.ebi.ac.uk/' +
                  'europepmc/webservices/rest/search/'
   this.opts = opts || {}
   eupmc.first = true
@@ -80,7 +80,7 @@ EuPmc.prototype.pageQuery = function () {
   }
 
   var rq = requestretry.get({url: thisQueryUrl,
-    maxAttempts: 50,
+    maxAttempts: 10,
     retryStrategy: retryOnHTTPNetOrEuPMCFailure,
     headers: {'User-Agent': config.userAgent}
   })


### PR DESCRIPTION
Fixes #168 

Change base URL to use https so Eupmc searching work again

Also reduce retry attempts to that it doesn't appear to hang forever

Also bump EuPMC api version number