### PR TITLE
Update EUPMC API to 5.3.2 (January 2018). Update query URL syntax.

### DIFF
--- a/lib/eupmc.js
+++ b/lib/eupmc.js
@@ -463,7 +463,7 @@ EuPmc.prototype.getFulltextXMLUrl = function (result) {
   var xmlurl = null
 
   if (id.type === 'pmcid') {
-    xmlurl = 'http://www.ebi.ac.uk/europepmc/webservices/rest/' +
+    xmlurl = 'https://www.ebi.ac.uk/europepmc/webservices/rest/' +
     id.id + '/fullTextXML'
   } else {
     log.warn('Article with ' + id.type + ' "' +
@@ -526,7 +526,7 @@ EuPmc.prototype.getSuppFilesUrl = function (result) {
   var id = eupmc.getIdentifier(result)
 
   if (id.type === 'pmcid') {
-    return ['http://www.ebi.ac.uk/europepmc/webservices/rest/' +
+    return ['https://www.ebi.ac.uk/europepmc/webservices/rest/' +
     id.id + '/supplementaryFiles', id.id]
   } else {
     log.warn('Article with ' + id.type + ' "' +
@@ -541,7 +541,7 @@ EuPmc.prototype.getMinedTermsURL = function (result) {
   var id = eupmc.getIdentifier(result)
 
   if (id.type === 'pmcid') {
-    return ['http://www.ebi.ac.uk/europepmc/webservices/rest/PMC/' +
+    return ['https://www.ebi.ac.uk/europepmc/webservices/rest/PMC/' +
     id.id + '/textMinedTerms//1/1000/json', id.id]
   } else {
     log.warn('Article with ' + id.type + ' "' +

--- a/lib/eupmc.js
+++ b/lib/eupmc.js
@@ -13,12 +13,12 @@ var log = require('winston')
 
 var parseString = require('xml2js').parseString
 
-var EuPMCVersion = '5.2.2'
+var EuPMCVersion = '5.3.2'
 
 var EuPmc = function (opts) {
   var eupmc = this
   this.baseurl = 'https://www.ebi.ac.uk/' +
-                 'europepmc/webservices/rest/search/'
+                 'europepmc/webservices/rest/search?'
   this.opts = opts || {}
   eupmc.first = true
   eupmc.hitlimit = eupmc.opts.hitlimit ? eupmc.opts.hitlimit : 0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "getpapers",
   "description": "Get fulltexts or fulltext URLs of papers matching a search query",
-  "version": "0.4.14",
+  "version": "0.4.17",
   "homepage": "https://github.com/ContentMine/getpapers",
   "author": {
     "name": "Richard Smith-Unna",


### PR DESCRIPTION
Fixes #171 

Updated EUPMC API version to 5.3.2.

Also changed format of base URL so that parameters are appended to URL ending '?' not '/' and tested.  Not aware whether the 5.2 API specified the slash-based pattern.

Added related commit which
Fixes #170

URLs for XML full text downloads and also supplemental data and text mined data converted to use https.  
Bumped version number to 0.4.17.
