### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/lib/crossref.js
+++ b/lib/crossref.js
@@ -94,7 +94,7 @@ CrossRef.prototype.formatResult = function (result) {
   }
 
   return parts.author + ' (' + parts.year + '). ' +
-  result.title + result.DOI ? ' http://dx.doi.org/' + result.DOI : ''
+  result.title + result.DOI ? ' https://doi.org/' + result.DOI : ''
 }
 
 CrossRef.prototype.handleSearchResults = function (crossref) {

--- a/lib/eupmc.js
+++ b/lib/eupmc.js
@@ -194,7 +194,7 @@ EuPmc.prototype.buildQuery = function (query, options) {
 EuPmc.prototype.formatResult = function (result) {
   return result.authorString +
   ' (' + result.pubYear + '). ' +
-  result.title + ' http://dx.doi.org/' + result.DOI
+  result.title + ' https://doi.org/' + result.DOI
 }
 
 EuPmc.prototype.handleSearchResults = function (eupmc) {


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old links with the `dx` subdomain continue to work.

So, there is no urgent need to do anything, but nonetheless, I'd like to suggest to hereby update the code that generates new ones.

Cheers!